### PR TITLE
Task 7

### DIFF
--- a/authorization-service/.gitignore
+++ b/authorization-service/.gitignore
@@ -1,0 +1,6 @@
+# package directories
+node_modules
+jspm_packages
+
+# Serverless directories
+.serverless

--- a/authorization-service/.gitignore
+++ b/authorization-service/.gitignore
@@ -4,3 +4,4 @@ jspm_packages
 
 # Serverless directories
 .serverless
+.env

--- a/authorization-service/handler.js
+++ b/authorization-service/handler.js
@@ -1,0 +1,18 @@
+'use strict';
+
+module.exports.hello = async event => {
+  return {
+    statusCode: 200,
+    body: JSON.stringify(
+      {
+        message: 'Go Serverless v1.0! Your function executed successfully!',
+        input: event,
+      },
+      null,
+      2
+    ),
+  };
+
+  // Use this code if you don't use the http event with the LAMBDA-PROXY integration
+  // return { message: 'Go Serverless v1.0! Your function executed successfully!', event };
+};

--- a/authorization-service/handler.js
+++ b/authorization-service/handler.js
@@ -1,18 +1,3 @@
-'use strict';
+import basicAuthorizerHandler from './handlers/basicAuthorizer';
 
-module.exports.hello = async event => {
-  return {
-    statusCode: 200,
-    body: JSON.stringify(
-      {
-        message: 'Go Serverless v1.0! Your function executed successfully!',
-        input: event,
-      },
-      null,
-      2
-    ),
-  };
-
-  // Use this code if you don't use the http event with the LAMBDA-PROXY integration
-  // return { message: 'Go Serverless v1.0! Your function executed successfully!', event };
-};
+export const basicAuthorizer = basicAuthorizerHandler;

--- a/authorization-service/handlers/basicAuthorizer.js
+++ b/authorization-service/handlers/basicAuthorizer.js
@@ -1,0 +1,55 @@
+export default (event, _context, callback) => {
+  console.log('basicAuthorizer:', event);
+
+  let isAllowed = true;
+  let message = 'Success';
+
+  const {
+    type,
+    methodArn,
+    authorizationToken,
+  } = event;
+
+  if (type !== 'TOKEN') return callback('Unauthorized');
+
+  try {
+    const authString = Buffer.from(authorizationToken, 'base64').toString('utf-8');
+    const [isBasic, token] = authString.split(' ');
+
+    console.log('basicAuthorizer, auth sting', authString);
+
+    if (isBasic !== 'Basic') return callback('Unauthorized');
+
+    const [login, password] = token.split(':');
+    const validPassword = process.env[login];
+
+    if (!validPassword || validPassword !== password) {
+      isAllowed = false;
+      message = 'Provided credentials is incorrect. Access denied';
+    }
+
+    const result = {
+      principalId: token,
+      context: {
+        message,
+      },
+      policyDocument: {
+        Version: '2012-10-17',
+        Statement: [
+          {
+            Action: 'execute-api:Invoke',
+            Effect: isAllowed ? 'Allow' : 'Deny',
+            Resource: methodArn,
+          },
+        ],
+      },
+    };
+
+    console.log('basicAuthorizer result', JSON.stringify(result));
+
+    return callback(null, result);
+  } catch (err) {
+    console.error('Error', err);
+    callback('Unauthorized');
+  }
+};

--- a/authorization-service/package.json
+++ b/authorization-service/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "authorization-service",
+  "version": "1.0.0",
+  "description": "AWS Auth",
+  "main": "handler.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tambovchanin/nodejs-aws-be.git"
+  },
+  "keywords": [
+    "Node.js",
+    "AWS",
+    "RSS",
+    "Serverless",
+    "Auth"
+  ],
+  "author": "tambovchanin@gmail.com",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/tambovchanin/nodejs-aws-be/issues"
+  },
+  "homepage": "https://github.com/tambovchanin/nodejs-aws-be#readme"
+}

--- a/authorization-service/package.json
+++ b/authorization-service/package.json
@@ -22,5 +22,13 @@
   "bugs": {
     "url": "https://github.com/tambovchanin/nodejs-aws-be/issues"
   },
-  "homepage": "https://github.com/tambovchanin/nodejs-aws-be#readme"
+  "homepage": "https://github.com/tambovchanin/nodejs-aws-be#readme",
+  "devDependencies": {
+    "@babel/core": "^7.12.9",
+    "@babel/preset-env": "^7.12.7",
+    "babel-loader": "^8.2.2",
+    "serverless-dotenv-plugin": "^3.1.0",
+    "serverless-plugin-webpack": "^1.5.1",
+    "webpack": "^5.8.0"
+  }
 }

--- a/authorization-service/serverless.yml
+++ b/authorization-service/serverless.yml
@@ -1,113 +1,30 @@
-# Welcome to Serverless!
-#
-# This file is the main config file for your service.
-# It's very minimal at this point and uses default values.
-# You can always add more config options for more control.
-# We've included some commented out config examples here.
-# Just uncomment any of them to get that config option.
-#
-# For full config options, check the docs:
-#    docs.serverless.com
-#
-# Happy Coding!
-
 service: authorization-service
-# app and org for use with dashboard.serverless.com
-#app: your-app-name
-#org: your-org-name
 
-# You can pin your service to only deploy with a specific Serverless version
-# Check out our docs for more details
 frameworkVersion: '2'
 
 provider:
   name: aws
   runtime: nodejs12.x
+  region: eu-west-1
+  profile: sdmAccount
 
-# you can overwrite defaults here
-#  stage: dev
-#  region: us-east-1
+  environment:
+    USER: ${env.USER}
+    PASS: ${env.PASS}
 
-# you can add statements to the Lambda function's IAM Role here
-#  iamRoleStatements:
-#    - Effect: "Allow"
-#      Action:
-#        - "s3:ListBucket"
-#      Resource: { "Fn::Join" : ["", ["arn:aws:s3:::", { "Ref" : "ServerlessDeploymentBucket" } ] ]  }
-#    - Effect: "Allow"
-#      Action:
-#        - "s3:PutObject"
-#      Resource:
-#        Fn::Join:
-#          - ""
-#          - - "arn:aws:s3:::"
-#            - "Ref" : "ServerlessDeploymentBucket"
-#            - "/*"
-
-# you can define service wide environment variables here
-#  environment:
-#    variable1: value1
-
-# you can add packaging information here
-#package:
-#  include:
-#    - include-me.js
-#    - include-me-dir/**
-#  exclude:
-#    - exclude-me.js
-#    - exclude-me-dir/**
+plugins:
+  - serverless-plugin-webpack
+  - serverless-dotenv-plugin
 
 functions:
-  hello:
-    handler: handler.hello
-#    The following are a few example events you can configure
-#    NOTE: Please make sure to change your handler code to work with those events
-#    Check the event documentation for details
-#    events:
-#      - http:
-#          path: users/create
-#          method: get
-#      - websocket: $connect
-#      - s3: ${env:BUCKET}
-#      - schedule: rate(10 minutes)
-#      - sns: greeter-topic
-#      - stream: arn:aws:dynamodb:region:XXXXXX:table/foo/stream/1970-01-01T00:00:00.000
-#      - alexaSkill: amzn1.ask.skill.xx-xx-xx-xx
-#      - alexaSmartHome: amzn1.ask.skill.xx-xx-xx-xx
-#      - iot:
-#          sql: "SELECT * FROM 'some_topic'"
-#      - cloudwatchEvent:
-#          event:
-#            source:
-#              - "aws.ec2"
-#            detail-type:
-#              - "EC2 Instance State-change Notification"
-#            detail:
-#              state:
-#                - pending
-#      - cloudwatchLog: '/aws/lambda/hello'
-#      - cognitoUserPool:
-#          pool: MyUserPool
-#          trigger: PreSignUp
-#      - alb:
-#          listenerArn: arn:aws:elasticloadbalancing:us-east-1:XXXXXX:listener/app/my-load-balancer/50dc6c495c0c9188/
-#          priority: 1
-#          conditions:
-#            host: example.com
-#            path: /hello
+  basicAuthorizer:
+    handler: handler.basicAuthorizer
 
-#    Define function environment variables here
-#    environment:
-#      variable2: value2
-
-# you can add CloudFormation resource templates here
-#resources:
-#  Resources:
-#    NewResource:
-#      Type: AWS::S3::Bucket
-#      Properties:
-#        BucketName: my-new-bucket
-#  Outputs:
-#     NewOutput:
-#       Description: "Description for the output"
-#       Value: "Some output value"
+resources:
+  Resources: {}
+  Outputs:
+    basicAuthorizerArn:
+      Value:
+        'Fn::GetAtt':
+          - BasicAuthorizerLambdaFunction
+          - Arn

--- a/authorization-service/serverless.yml
+++ b/authorization-service/serverless.yml
@@ -1,0 +1,113 @@
+# Welcome to Serverless!
+#
+# This file is the main config file for your service.
+# It's very minimal at this point and uses default values.
+# You can always add more config options for more control.
+# We've included some commented out config examples here.
+# Just uncomment any of them to get that config option.
+#
+# For full config options, check the docs:
+#    docs.serverless.com
+#
+# Happy Coding!
+
+service: authorization-service
+# app and org for use with dashboard.serverless.com
+#app: your-app-name
+#org: your-org-name
+
+# You can pin your service to only deploy with a specific Serverless version
+# Check out our docs for more details
+frameworkVersion: '2'
+
+provider:
+  name: aws
+  runtime: nodejs12.x
+
+# you can overwrite defaults here
+#  stage: dev
+#  region: us-east-1
+
+# you can add statements to the Lambda function's IAM Role here
+#  iamRoleStatements:
+#    - Effect: "Allow"
+#      Action:
+#        - "s3:ListBucket"
+#      Resource: { "Fn::Join" : ["", ["arn:aws:s3:::", { "Ref" : "ServerlessDeploymentBucket" } ] ]  }
+#    - Effect: "Allow"
+#      Action:
+#        - "s3:PutObject"
+#      Resource:
+#        Fn::Join:
+#          - ""
+#          - - "arn:aws:s3:::"
+#            - "Ref" : "ServerlessDeploymentBucket"
+#            - "/*"
+
+# you can define service wide environment variables here
+#  environment:
+#    variable1: value1
+
+# you can add packaging information here
+#package:
+#  include:
+#    - include-me.js
+#    - include-me-dir/**
+#  exclude:
+#    - exclude-me.js
+#    - exclude-me-dir/**
+
+functions:
+  hello:
+    handler: handler.hello
+#    The following are a few example events you can configure
+#    NOTE: Please make sure to change your handler code to work with those events
+#    Check the event documentation for details
+#    events:
+#      - http:
+#          path: users/create
+#          method: get
+#      - websocket: $connect
+#      - s3: ${env:BUCKET}
+#      - schedule: rate(10 minutes)
+#      - sns: greeter-topic
+#      - stream: arn:aws:dynamodb:region:XXXXXX:table/foo/stream/1970-01-01T00:00:00.000
+#      - alexaSkill: amzn1.ask.skill.xx-xx-xx-xx
+#      - alexaSmartHome: amzn1.ask.skill.xx-xx-xx-xx
+#      - iot:
+#          sql: "SELECT * FROM 'some_topic'"
+#      - cloudwatchEvent:
+#          event:
+#            source:
+#              - "aws.ec2"
+#            detail-type:
+#              - "EC2 Instance State-change Notification"
+#            detail:
+#              state:
+#                - pending
+#      - cloudwatchLog: '/aws/lambda/hello'
+#      - cognitoUserPool:
+#          pool: MyUserPool
+#          trigger: PreSignUp
+#      - alb:
+#          listenerArn: arn:aws:elasticloadbalancing:us-east-1:XXXXXX:listener/app/my-load-balancer/50dc6c495c0c9188/
+#          priority: 1
+#          conditions:
+#            host: example.com
+#            path: /hello
+
+#    Define function environment variables here
+#    environment:
+#      variable2: value2
+
+# you can add CloudFormation resource templates here
+#resources:
+#  Resources:
+#    NewResource:
+#      Type: AWS::S3::Bucket
+#      Properties:
+#        BucketName: my-new-bucket
+#  Outputs:
+#     NewOutput:
+#       Description: "Description for the output"
+#       Value: "Some output value"

--- a/authorization-service/webpack.config.js
+++ b/authorization-service/webpack.config.js
@@ -1,0 +1,15 @@
+const { IgnorePlugin } = require('webpack');
+
+module.exports = {
+  target: 'node',
+  mode: 'production',
+  module: {
+    rules: [
+      {
+        exclude: /node_modules/,
+        loader: 'babel-loader',
+        test: /\.js$/,
+      },
+    ],
+  },
+};

--- a/import-service/common/responseWrapper.js
+++ b/import-service/common/responseWrapper.js
@@ -3,11 +3,10 @@ import RequestError from './RequestError';
 export default handler => async event => {
   const headers = {
     'Access-Control-Allow-Origin': '*',
-    'Access-Control-Allow-Headers': 'Access-Control-Allow-Origin'
   }
   let result;
 
-  const answer = (data, statusCode = 200) => ({
+  const answer = (data = {}, statusCode = 200) => ({
     headers,
     statusCode,
     body: JSON.stringify(data),

--- a/import-service/serverless.yml
+++ b/import-service/serverless.yml
@@ -43,6 +43,26 @@ plugins:
 
 resources:
   Resources:
+    GatewayResponseUnauthorized:
+      Type: AWS::ApiGateway::GatewayResponse
+      Properties:
+        ResponseParameters:
+          gatewayresponse.header.Access-Control-Allow-Origin: "'*'"
+          gatewayresponse.header.Access-Control-Allow-Headers: "'*'"
+        ResponseType: UNAUTHORIZED
+        RestApiId:
+          Ref: ApiGatewayRestApi
+        StatusCode: 401
+    GatewayResponseAccessDenied:
+      Type: AWS::ApiGateway::GatewayResponse
+      Properties:
+        ResponseParameters:
+          gatewayresponse.header.Access-Control-Allow-Origin: "'*'"
+          gatewayresponse.header.Access-Control-Allow-Headers: "'*'"
+        ResponseType: ACCESS_DENIED
+        RestApiId:
+          Ref: ApiGatewayRestApi
+        StatusCode: 403
     SqsQueue:
       Type: AWS::SQS::Queue
       Properties:
@@ -62,6 +82,12 @@ functions:
           path: import
           method: get
           cors: true
+          authorizer:
+            name: tokenAuthorizer
+            arn: '${cf:authorization-service-${self:provider.stage}.basicAuthorizerArn}'
+            resultTtlInSeconds: 0
+            identitySource: method.request.header.Authorization
+            type: token
           request:
             parameters:
               querystrings:


### PR DESCRIPTION
https://github.com/tambovchanin/nodejs-aws-be/pull/5/commits## Task 7 [description](https://github.com/rolling-scopes-school/nodejs-aws-tasks/blob/main/task7-lambda%2Bcognito-authorization/task.md)

### Links

 - FE - https://dagfo33jvtmc.cloudfront.net/
 - FE changes in [PR](https://github.com/tambovchanin/nodejs-aws-fe/pull/4)

### Evaluation criteria
- [x] - authorization-service is added to the repo, has correct basicAuthorizer lambda and correct serverless.yaml file
- [x] - import-service serverless.yaml file has authorizer configuration for the importProductsFile lambda. Request to the importProductsFile lambda should work only with correct authorization_token being decoded and checked by basicAuthorizer lambda. Response should be in 403 HTTP status if access is denied for this user (invalid authorization_token) and in 401 HTTP status if Authorization header is not provided.
- [x] - update client application to send Authorization: Basic authorization_token header on import. Client should get authorization_token value from browser **localStorage authorization_token = localStorage.getItem('authorization_token')**

### Additional (optional) tasks
- [x] - Client application should display alerts for the responses in 401 and 403 HTTP statuses. (FE changes in [PR](https://github.com/tambovchanin/nodejs-aws-fe/pull/4))

### Test import file
```csv
title,image,description,price,stock,
Watch 1,https://source.unsplash.com/daily/?watch,Watch Description 1,11,2,
Watch 2,https://source.unsplash.com/daily/?watch,Watch Description 2,12,1,
Watch 3,https://source.unsplash.com/daily/?watch,Watch Description 3,13,3,
```

**Self control score - 6**