### PR TITLE
Task 9

### DIFF
--- a/bff-service/.gitignore
+++ b/bff-service/.gitignore
@@ -1,0 +1,15 @@
+# Build files
+dist
+
+# Serverless directories
+.serverless
+.env
+
+# Elastic Beanstalk Files
+.ebextensions/*
+.elasticbeanstalk/*
+!.elasticbeanstalk/*.cfg.yml
+!.elasticbeanstalk/*.global.yml
+
+# package directories
+node_modules

--- a/bff-service/nest-cli.json
+++ b/bff-service/nest-cli.json
@@ -1,0 +1,4 @@
+{
+  "collection": "@nestjs/schematics",
+  "sourceRoot": "src"
+}

--- a/bff-service/package.json
+++ b/bff-service/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "bff-service",
+  "version": "1.0.0",
+  "description": "BFF Service",
+  "scripts": {
+    "prebuild": "rimraf dist",
+    "build": "nest build",
+    "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
+    "start": "nest start",
+    "start:dev": "nest start --watch",
+    "start:debug": "nest start --debug --watch",
+    "start:prod": "node dist/main",
+    "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
+  },
+  "dependencies": {
+    "@nestjs/common": "^7.5.1",
+    "@nestjs/config": "^0.6.1",
+    "@nestjs/core": "^7.5.1",
+    "@nestjs/platform-express": "^7.5.1",
+    "cache-manager": "^3.4.0",
+    "reflect-metadata": "^0.1.13",
+    "rimraf": "^3.0.2",
+    "rxjs": "^6.6.3"
+  },
+  "devDependencies": {
+    "@nestjs/cli": "^7.5.1",
+    "@nestjs/schematics": "^7.1.3",
+    "@nestjs/testing": "^7.5.1",
+    "@types/cache-manager": "^2.10.3",
+    "@types/express": "^4.17.8",
+    "@types/node": "^14.14.6",
+    "@types/supertest": "^2.0.10",
+    "@typescript-eslint/eslint-plugin": "^4.6.1",
+    "@typescript-eslint/parser": "^4.6.1",
+    "eslint": "^7.12.1",
+    "eslint-config-prettier": "7.0.0",
+    "eslint-plugin-prettier": "^3.1.4",
+    "jest": "^26.6.3",
+    "prettier": "^2.1.2",
+    "supertest": "^6.0.0",
+    "ts-jest": "^26.4.3",
+    "ts-loader": "^8.0.8",
+    "ts-node": "^9.0.0",
+    "tsconfig-paths": "^3.9.0",
+    "typescript": "^4.0.5"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tambovchanin/nodejs-aws-be.git"
+  },
+  "keywords": [
+    "Node.js",
+    "AWS",
+    "RSS",
+    "Serverless"
+  ],
+  "author": "tambovchanin@gmail.com",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/tambovchanin/nodejs-aws-be/issues"
+  },
+  "homepage": "https://github.com/tambovchanin/nodejs-aws-be#readme"
+}

--- a/bff-service/src/app.controller.ts
+++ b/bff-service/src/app.controller.ts
@@ -1,0 +1,64 @@
+import { All, CACHE_MANAGER, Controller, Inject, Req, Res } from '@nestjs/common';
+import { Method } from 'axios';
+import { Cache } from 'cache-manager';
+import { Request, Response } from 'express';
+
+import { DiscoveryService } from './discovery.service';
+import { ProxyService } from './proxy.service';
+
+@Controller()
+export class AppController {
+  constructor(
+      @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
+      private readonly discoveryService: DiscoveryService,
+      private readonly proxyService: ProxyService,
+  ) {
+  }
+
+  protected getCacheParameters(serviceName: string, servicePath: string, method: Method): {
+    key: string, statuses: number[], ttl: number
+  } | null {
+    if (serviceName === 'product' && servicePath === '' && method.toLowerCase() === 'get') {
+      return {
+        key: 'product',
+        statuses: [ 200 ],
+        ttl: 600, // seconds
+      };
+    }
+
+    return null;
+  }
+
+  @All()
+  async proxy<T>(@Req() req: Request, @Res() res: Response): Promise<void> {
+    const method = req.method as Method;
+    const {
+      cacheManager,
+      proxyService,
+      discoveryService,
+      getCacheParameters
+    } = this;
+    const { serviceName, servicePath, url } = discoveryService.discoverEndpoint(req.path);
+    const body = req.body;
+
+    const cacheParameters = getCacheParameters(serviceName, servicePath, method);
+    if (cacheParameters) {
+      const cached = await cacheManager.get(cacheParameters.key);
+
+      if (cached) {
+        res.send(cached);
+        return;
+      }
+    }
+
+    const { data, status } = await proxyService.request(method, url, body);
+
+    if (cacheParameters) {
+      if (cacheParameters.statuses.includes(status)) {
+        await cacheManager.set(cacheParameters.key, data, { ttl: cacheParameters.ttl });
+      }
+    }
+
+    res.status(status).send(data);
+  }
+}

--- a/bff-service/src/app.module.ts
+++ b/bff-service/src/app.module.ts
@@ -1,0 +1,26 @@
+import {
+  Module,
+  CacheModule,
+  HttpModule,
+} from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { AppController } from './app.controller';
+import { DiscoveryService } from './discovery.service';
+import { ProxyService } from './proxy.service';
+
+@Module({
+  imports: [
+    CacheModule.register(),
+    ConfigModule.forRoot(),
+    HttpModule,
+  ],
+  controllers: [
+    AppController,
+  ],
+  providers: [
+    DiscoveryService,
+    ProxyService,
+  ],
+})
+
+export class AppModule {}

--- a/bff-service/src/discovery.service.ts
+++ b/bff-service/src/discovery.service.ts
@@ -1,0 +1,34 @@
+import { BadGatewayException, Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+@Injectable()
+export class DiscoveryService {
+  constructor(private readonly configService: ConfigService) {
+  }
+
+  public getServiceUrl(serviceName: string): string {
+    const key = `${serviceName.toUpperCase()}_SERVICE_URL`;
+
+    const serviceUrl = this.configService.get(key);
+
+    if (!serviceUrl) {
+      throw new BadGatewayException(`Cannot process request for service ${serviceName}`);
+    }
+
+    return serviceUrl;
+  }
+
+  public discoverEndpoint(path: string): { serviceName: string, servicePath: string, serviceUrl: string, url: string } {
+    const [, serviceName, ...rawServicePathParts] = path.split('/');
+    const serviceUrl = this.getServiceUrl(serviceName);
+    const servicePathParts = rawServicePathParts.filter(part => part !== '');
+    const servicePath = servicePathParts.length > 0 ? `/${servicePathParts.join('/')}` : '';
+
+    return {
+      serviceName,
+      servicePath,
+      serviceUrl,
+      url: serviceUrl + servicePath,
+    };
+  }
+}

--- a/bff-service/src/main.ts
+++ b/bff-service/src/main.ts
@@ -1,0 +1,10 @@
+import { NestFactory } from '@nestjs/core';
+
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(3000);
+}
+
+bootstrap();

--- a/bff-service/src/proxy.service.ts
+++ b/bff-service/src/proxy.service.ts
@@ -1,0 +1,30 @@
+import { BadGatewayException, HttpService, Injectable } from '@nestjs/common';
+import { Method } from 'axios';
+
+@Injectable()
+export class ProxyService {
+  constructor(private readonly httpService: HttpService) {
+  }
+
+  public async request<T>(method: Method, url: string, body?: any): Promise<{ data: T; status: number }> {
+    const data = ['patch', 'post', 'put'].includes(method.toLowerCase()) ? body : undefined;
+
+    const res = await this.httpService.request<T>({
+      data,
+      method,
+      url,
+    }).toPromise()
+        .catch((error) => {
+          if (error.response) {
+            return error.response;
+          } else {
+            throw new BadGatewayException();
+          }
+        });
+
+    return {
+      data: res.data,
+      status: res.status,
+    };
+  }
+}

--- a/bff-service/tsconfig.build.json
+++ b/bff-service/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "dist"]
+}

--- a/bff-service/tsconfig.json
+++ b/bff-service/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "es2017",
+    "sourceMap": true,
+    "outDir": "./dist",
+    "baseUrl": "./",
+    "incremental": true
+  }
+}


### PR DESCRIPTION
## Task 9 [description](https://github.com/rolling-scopes-school/nodejs-aws-tasks/blob/main/task9-bff/task.md)

### Evaluation criteria (each mark includes previous mark criteria)
Provide your reviewers with the following information:

- product-service service API endpoint URL
- example of the create product API call with all needed information: URL, payload, headers, etc.
- CART service API endpoint URL
- bff-service service URL
- example how to call product-service and CART services via bff-service service URL
- [x] - A working and correct express application should be in the bff-service folder. Reviewer can start this application locally with any valid configuration in the .env file and this application should works as described in the task 9.1
- [x] - The bff-service should be deployed with Elastic Beanstalk. The bff-service call should be redirected to the appropriate service : product-service or CART. The response from the bff-service should be the same as if product-service or CART services were called directly.
### Additional (optional) tasks
- [x] - Add a cache at the bff-service level for a request to the getProductsList function of the product-service. The cache should expire in 2 minutes.
- [x] - Use NestJS to create bff-service instead of express

**Self test score  - 7**